### PR TITLE
ブログ投稿一覧の表示機能を追加

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -15,6 +15,7 @@ class PostController extends Controller
     */
     public function index(Post $post) //インポートしたPostをインスタンス化して$postとして使用。
     {
-        return $post->get(); //$postの中身を戻り値にする。
+        // blade内で使う変数'posts'と設定。'posts'の中身にgetを使い、インスタンス化した$postを代入。
+        return view('posts.index')->with(['posts' => $post->get()]);
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -15,7 +15,7 @@ class PostController extends Controller
     */
     public function index(Post $post) //インポートしたPostをインスタンス化して$postとして使用。
     {
-        // blade内で使う変数'posts'と設定。'posts'の中身にgetを使い、インスタンス化した$postを代入。
-        return view('posts.index')->with(['posts' => $post->get()]);
+        // blade内で使う変数'posts'と設定。'posts'の中身にgetPaginateByLimitを使い、インスタンス化した$postを代入。
+        return view('posts.index')->with(['posts' => $post->getPaginateByLimit()]);
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,7 +9,7 @@ class Post extends Model
 {
     use HasFactory;
     
-    // 取得データの最大件数を10件以下に指定
+    // 取得データの最大件数を5件以下に指定
     public function getPaginateByLimit(int $limit_count = 5)
     {
         // updated_atで降順に並べた後、limitで件数制限をかける

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -8,4 +8,11 @@ use Illuminate\Database\Eloquent\Model;
 class Post extends Model
 {
     use HasFactory;
+    
+    // 取得データの最大件数を10件以下に指定
+    public function getPaginateByLimit(int $limit_count = 5)
+    {
+        // updated_atで降順に並べた後、limitで件数制限をかける
+        return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,8 +18,8 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Bootstrap any application services.
      */
-    public function boot(): void
+    public function boot()
     {
-        //
+        Paginator::useBootstrapFive();
     }
 }

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -13,6 +13,7 @@
     <body>
         <h1>Blog Name</h1>
         <div class='posts'>
+            <!--ブログ投稿一覧を展開して表示-->
             @foreach ($posts as $post)
                 <div class='post'>
                     <h2 class='title'>{{ $post->title }}</h2>
@@ -20,5 +21,7 @@
                 </div>
             @endforeach
         </div>
+        <!--ページネーションリンク-->
+        <div class='paginate'>{{ $posts->links() }}</div>
     </body>
 </html>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale() )}}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+        <title>Blog</title>
+        
+        <!--フォント-->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    
+    <body>
+        <h1>Blog Name</h1>
+        <div class='posts'>
+            @foreach ($posts as $post)
+                <div class='post'>
+                    <h2 class='title'>{{ $post->title }}</h2>
+                    <p class='body'>{{ $post->body }}</p>
+                </div>
+            @endforeach
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,9 +14,4 @@ use App\Http\Controllers\PostController; //外部にあるPostControllerクラ�
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
-
-// /postsへのGETリクエストがあった場合、PostControllerクラスのindexメソッドを呼び出すように設定
-Route::get('/posts', [PostController::class, 'index']);
+Route::get('/', [PostController::class, 'index']);


### PR DESCRIPTION
## 概要
ブログ投稿一覧の表示機能を追加しました。また、1ページの表示上限を5件に制限し、ページネーションを導入しました。

## 変更内容
- PostモデルにgetPaginateByLimitメソッドを追加
- PostコントローラーにgetPaginateLimitメソッドを追加し、ブログ投稿一覧を取得できるように設定
- bladeにページネーションリンクを追加