### PR TITLE
ブログ投稿詳細画面の作成

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -18,4 +18,16 @@ class PostController extends Controller
         // blade内で使う変数'posts'と設定。'posts'の中身にgetPaginateByLimitを使い、インスタンス化した$postを代入。
         return view('posts.index')->with(['posts' => $post->getPaginateByLimit()]);
     }
+    
+    /**
+     * 特定IDのpostを表示する
+     * 
+     * @params Object Post /／引数の＄postはid=1のPostインスタンス
+     * @return Reposnes post view
+     */
+     public function show(Post $post)
+     {
+         // 'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
+         return view('posts.show')->with(['post' => $post]);
+     }
 }

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -16,7 +16,10 @@
             <!--ブログ投稿一覧を展開して表示-->
             @foreach ($posts as $post)
                 <div class='post'>
-                    <h2 class='title'>{{ $post->title }}</h2>
+                        <h2 class='title'>
+                            <!--各投稿へのリンクとしてタイトルを表示-->
+                            <a href="/posts/{{ $post->id }}">{{ $post->title }}</a>
+                        </h2>
                     <p class='body'>{{ $post->body }}</p>
                 </div>
             @endforeach

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale() )}}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+        <title>Post</title>
+        
+        <!--フォント-->
+        <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+    </head>
+    
+    <body>
+        <!--ブログタイトル-->
+        <h1 class="title">
+            {{ $post->title }}
+        </h1>
+        <div class='content'>
+            <!--ブログ本文-->
+            <div class='contnt__post'>
+                <h3>本文</h3>
+                <p class='body'>{{ $post->body }}</p>
+            </div>
+        </div>
+        
+        <!--フッター-->
+        <div class="footer">
+            <a href="/">戻る</a>
+        </div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,4 +14,10 @@ use App\Http\Controllers\PostController; //外部にあるPostControllerクラ�
 |
 */
 
+// ブログ投稿一覧画面
+// '/'にGetリクエストが来たら
 Route::get('/', [PostController::class, 'index']);
+
+// ブログ投稿詳細画面
+// '/posts/{対象データのID}'にGetリクエストが来たら、PostControllerのshowメソッドを実行する。
+Route::get('/posts/{post}', [PostController::class, 'show']);


### PR DESCRIPTION
### 概要
ブログ投稿詳細画面を作成し、一覧ページのタイトルをクリックすると各投稿ページに遷移するように設定しました。

### 変更内容
- ブログ投稿詳細画面用のshow.blade.phpを作成
- PostControllerにshow関数を追加
- show関数が実行されるルーティング定義を追加