### PR TITLE
feat: カテゴリー機能を追加

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Category; //カテゴリー情報を使用するため
+
+class CategoryController extends Controller
+{
+    /**
+     * 指定したカテゴリー名のブログ投稿を表示
+     * 
+     * @param Category
+     */ 
+    public function index(Category $category)
+    {
+        return view('categories.index')->with(['posts' => $category->getByCategory()]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Post; // use宣言、App\Models内のPostクラスをインポート。
-use App\Http\Requests\PostRequest; //バリデーションを使用するためstore関数で使用
+use App\Http\Requests\PostRequest; // バリデーションを使用するためstore関数で使用
+use App\Models\Category; // カテゴリーを使用するため
 
 class PostController extends Controller
 {
@@ -23,24 +24,25 @@ class PostController extends Controller
     /**
      * 特定IDのpostを表示する
      * 
-     * @params Object Post /／引数の＄postはid=1のPostインスタンス
+     * @params Object Post /／引数の＄postはリクエストされたidのPostインスタンス
      * @return Responses post view
      */
      public function show(Post $post)
      {
-        // 'post'はbladeファイルで使う変数。中身は$postはid=1のPostインスタンス。
+        // 'post'はbladeファイルで使う変数。中身は$postはリクエストされたidのPostインスタンス。
         return view('posts.show')->with(['post' => $post]);
      }
      
     /**
      * ブログ作成画面を表示する
      * 
+     * @params Object Category
      * @return Responses create view
      */
-    public function create()
+    public function create(Category $category)
     {
-        //  ブログ作成画面を表示する
-        return view('posts.create');
+        //  ブログ作成画面を表示する。withメソッドでカテゴリー名を全て取得
+        return view('posts.create')->with(['categories' => $category->get()]);
     }
      
     /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -19,4 +19,14 @@ class Category extends Model
         // 関連する複数のPostインスタンスを呼び出す
         return $this->hasMany(Post::class);
     }
+    
+    /**
+     * カテゴリー別に記事を取得する
+     * 
+     * @param int $limit_count 取得する記事数
+     */
+    public function getByCategory(int $limit_count = 5)
+    {
+        return $this->posts()->with('category')->orderBy('updated_at', 'DESC')->paginate($limit_count);
+    }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -8,4 +8,15 @@ use Illuminate\Database\Eloquent\Model;
 class Category extends Model
 {
     use HasFactory;
+    
+    /**
+     * @return Post
+     * 
+     * 1対多なのでpostsは複数形
+     */
+    public function posts()
+    {
+        // 関連する複数のPostインスタンスを呼び出す
+        return $this->hasMany(Post::class);
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -24,11 +24,18 @@ class Post extends Model
         'category_id',
     ];
     
-    // 取得データの最大件数を5件以下に指定
+    /**
+     * 取得データの最大件数を5件以下に指定してページネイトできるようにする。
+     * 
+     * 「Eagerロードについて」
+     * withメソッドを使用した書き方はEagerロードという機能を使う書き方で、全てのデータを取得する際のクエリ数を2つだけに減らす機能。
+     * メリットは、クエリを減らすことでアプリケーションの動作が軽くなることや、「N+1クエリ問題」を軽減できることなどがある。
+     * もし、このEagerロードを使用しない場合は、「データの個数+1」回のクエリを実行する(例えば、ブログが10投稿あれば11回クエリを実行する)。
+     */
     public function getPaginateByLimit(int $limit_count = 5)
     {
-        // updated_atで降順に並べた後、limitで件数制限をかける
-        return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+        // リレーションしているカテゴリーを取得し、updated_atで降順に並べた後、limitで件数制限をかけて表示する
+        return $this::with('category')->orderBy('updated_at', 'DESC')->paginate($limit_count);
     }
     
     /**

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use HasFactory;
+    
     //論理削除を行うためSoftDeletesトレイトを追加
     use SoftDeletes;
     
@@ -19,15 +21,24 @@ class Post extends Model
     protected $fillable = [
         'title',
         'body',
+        'category_id',
     ];
-    
-    use HasFactory;
-    
     
     // 取得データの最大件数を5件以下に指定
     public function getPaginateByLimit(int $limit_count = 5)
     {
         // updated_atで降順に並べた後、limitで件数制限をかける
         return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+    }
+    
+    /**
+     * @return Category
+     * 
+     * 1対多なのでcategoryは単数系
+     */
+    public function category()
+    {
+        // 関連する1つのPostモデルのインスタンスを呼び出す
+        return $this->belongsTo(Category::class);
     }
 }

--- a/database/migrations/2024_01_28_022413_create_categories_table.php
+++ b/database/migrations/2024_01_28_022413_create_categories_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * Categoryテーブル作成
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50); // 50文字以下のカテゴリー名
+            $table->timestamps(); // created_atとupdated_at
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_01_28_024906_add_category_id_to_posts_table.php
+++ b/database/migrations/2024_01_28_024906_add_category_id_to_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * 
+     * postsテーブルに外部キー（category_id）のカラムを追加
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            /*
+            categoriesテーブルのidを参照する外部キーを追加。
+            onDelete('cascade')を設定すると、紐づいているお互いのデータが同時に削除される。
+            */
+            $table->foreignId('category_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -38,6 +38,9 @@
                     </form>
                 </div>
             @endforeach
+            
+            <a href="/">ホームに戻る</a>
+            
         </div>
         <!--ページネーションリンク-->
         <div class="paginate">{{ $posts->links() }}</div>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -40,6 +40,19 @@
                 <p class="body__error" style="color: red">{{ $errors->first('post.body') }}</p>
             </div>
             
+            <!--カテゴリー選択selectフォーム-->
+            <div class="category">
+                <label>
+                    カテゴリー
+                    <select name="post[category_id]">
+                        <!--$categories内の全件データから1件ずつ表示。実際に送信されるのはvalueに指定された値-->
+                        @foreach($categories as $category)
+                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                </label>
+            </div>
+            
             <!--保存ボタン-->
             <div class="submit">
                 <input type="submit" value="投稿する" />

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -23,6 +23,9 @@
                         </h2>
                     <p class="body">{{ $post->body }}</p>
                     
+                    <!--カテゴリー名-->
+                    <a href="">{{ $post->category->name }}</a>
+                    
                     <!--ブログ削除ボタンForm-->
                     <form action="/posts/{{ $post->id }}" id="form_{{ $post->id }}" method="POST">
                         <!--csrf保護-->

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -25,6 +25,9 @@
             </div>
         </div>
         
+        <!--カテゴリー名-->
+        <a href="">{{ $post->category->name }}</a>
+        
         <!--フッター-->
         <div class="footer">
             <!--一覧画面に戻るボタン-->

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController; //外部にあるPostControllerクラスをインポート
+use App\Http\Controllers\CategoryController; // CategoryControllerをインポート
 
 /*
 |--------------------------------------------------------------------------
@@ -44,3 +45,6 @@ Route::put('/posts/{post}', [PostController::class, 'update']);
 
 // ブログ削除を実行する
 Route::delete('/posts/{post}', [PostController::class, 'delete']);
+
+// カテゴリーごとのページを表示する
+Route::get('/categories/{category}', [CategoryController::class, 'index']);


### PR DESCRIPTION
### 概要
カテゴリー機能を追加。カテゴリーとブログ投稿のリレーションを実装。

### 変更点
- CategoryモデルとCategoryControllerの作成
- リレーションを実装するため、 Postモデルにcategory_idカラムを追加
- CategoryモデルとPostモデルに1対多のリレーションを設定
- PostControllerのcreateメソッドでカテゴリー名を全て取得し、投稿時に選択可能に変更
- create.blade.phpのselectフォームでカテゴリーのidも送信するように変更
- CategoryControllerに指定したカテゴリーのブログ一覧を表示する機能を追加
- カテゴリーごとのページを表示するルーティングの追加

### 動作確認
1. ブログ作成画面でカテゴリーを選択してブログを作成
2. 作成したブログの詳細画面で選択したカテゴリーが表示されることを確認
3. カテゴリーごとのページにアクセスして、そのカテゴリーのブログが表示されることを確認