### PR TITLE
feat: teratail APIから質問データを取得し、ブログ一覧ページに表示

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -17,8 +17,27 @@ class PostController extends Controller
      */
     public function index(Post $post) //インポートしたPostをインスタンス化して$postとして使用。
     {
+        // GuzzleHttpを用いてクライアントインスタンス生成
+        $client = new \GuzzleHttp\Client();
+        // GETリクエストで最新の質問データを取得するためのURL
+        $url = 'https://teratail.com/api/v1/questions';
+        
+        // GETリクエスト送信と返却データの取得（Bearerトークンにアクセストークンを指定して認証を行う）
+        $response = $client->request(
+            'GET',
+            $url,
+            ['Bearer' => config('services.teratail.token')]
+        );
+        
+        // API通信で取得したデータはjson形式なのでPHPファイルに対応した連想配列にデコードする
+        $questions = json_decode($response->getBody(), true);
+        
         // blade内で使う変数'posts'と設定。'posts'の中身にgetPaginateByLimitを使い、インスタンス化した$postを代入。
-        return view('posts.index')->with(['posts' => $post->getPaginateByLimit()]);
+        // TeratailAPIから取得した質問一覧データをindex.blade.phpに$questionsとして渡す
+        return view('posts.index')->with([
+            'posts' => $post->getPaginateByLimit(),
+            'questions' => $questions['questions'],
+        ]);
     }
     
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^7.8",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c83b06f5f51dc9e949582b2409ddc64b",
+    "content-hash": "3485d906c2ead13a5cbac1210354d046",
     "packages": [
         {
             "name": "brick/math",

--- a/config/services.php
+++ b/config/services.php
@@ -30,5 +30,9 @@ return [
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
+    
+    'teratail' => [
+        'token' => env('TERATAIL_ACCESS_TOKEN')
+    ],
 
 ];

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -49,7 +49,18 @@
             <!--ページネーションリンク-->
             <div class="paginate">{{ $posts->links() }}</div>
             <p>ログインユーザー : {{ Auth::user()->name }}</p>
+            
+            <!--teratail APIから取得した質問データ一覧を表示する-->
+            <div>
+                @foreach($questions as $question)
+                    <div>
+                        <a href="https://teratail.com/questions/{{ $question['id'] }}">{{ $question['title'] }}</a>
+                    </div>
+                @endforeach
+            </div>
+            
         </x-app-layout>
+        
         <!--JavaScript-->
         <script>
             /**


### PR DESCRIPTION
### Guzzleを使用してteratail APIから質問データを取得し、ブログ一覧ページに表示しました。

### 変更内容
- PostControllerでAPIからデータを取得し、json形式からPHPの連想配列にデコード
- PostControllerでAPIから取得したデータをndex.blade.phpに$questionsとして渡す
- index.blade.phpで取得した質問データのタイトルをリンクとして表示